### PR TITLE
fixed model references for 'constructor'

### DIFF
--- a/lib/ngrams.js
+++ b/lib/ngrams.js
@@ -34,7 +34,7 @@
         token = '.';
       }
 
-      if (!options.model.data[options.previous]) {
+      if (!options.model.data.hasOwnProperty(options.previous)) {
         options.model.data[options.previous] = [token];
         options.model.typeCount++;
       } else {
@@ -112,7 +112,7 @@
      */
     var done = function() {
       if (options.previous !== '.') {
-        if (!options.model.data[options.previous]) {
+        if (!options.model.data.hasOwnProperty(options.previous)) {
           options.model.data[options.previous] = ['.'];
         } else {
           options.model.data[options.previous].push('.');


### PR DESCRIPTION
I ran into an issue where the word 'constructor' was in my corpus. Since every object has a constructor property, the model.data object returned the constructor of the object rather than undefined to indicate that it did not have an entry for 'constructor' in its model.